### PR TITLE
editable messages + bugfixes

### DIFF
--- a/ChannelLinker.js
+++ b/ChannelLinker.js
@@ -112,7 +112,7 @@ class ChannelLinker extends global.Discord.Client {
                     embed: new Discord.MessageEmbed()
                         .setAuthor('Some files not successfully sent!')
                         .setDescription(`The following files were unable to be sent: ${blockedAttachments.map(blockedAttachment => blockedAttachment.url).join(' , ')} . `+
-                        ((msg.attachments.size > 1) ? "Please try uploading these files in a seperate message for others to see them." : 
+                        (data.files.length ? "Please try uploading these files in a seperate message for others to see them." : 
                         (user.isNitro ? "The bot cannot upload an 8MB+ file like a nitro user" :
                         "Due to it being next to impossible to determine if a file sent by a user can be sent to all connected channels by the bot, the limit we use has been reduced a little bit below the actual limit provided by discord. We're very sorry for the inconvenience.")))
                         .setColor(0xD5622C)

--- a/ChannelLinker.js
+++ b/ChannelLinker.js
@@ -111,7 +111,7 @@ class ChannelLinker extends global.Discord.Client {
                 msg.author.send({
                     embed: new Discord.MessageEmbed()
                         .setAuthor('Some files not successfully sent!')
-                        .setDescription(`The following files were unable to be sent: ${blockedAttachments.map(blockedAttachment => blockedAttachment.url).join(',')}.`+
+                        .setDescription(`The following files were unable to be sent: ${blockedAttachments.map(blockedAttachment => blockedAttachment.url).join(' , ')} . `+
                         ((msg.attachments.size > 1) ? "Please try uploading these files in a seperate message for others to see them." : 
                         (user.isNitro ? "The bot cannot upload an 8MB+ file like a nitro user" :
                         "Due to it being next to impossible to determine if a file sent by a user can be sent to all connected channels by the bot, the limit we use has been reduced a little bit below the actual limit provided by discord. We're very sorry for the inconvenience.")))

--- a/ChannelLinker.js
+++ b/ChannelLinker.js
@@ -61,12 +61,13 @@ class ChannelLinker extends global.Discord.Client {
         return new Promise((resolve) => {
             this.users.fetch(userId).then(user => {
                 const data = {
-                    avatar: user.avatarURL({
+                    avatar: user.displayAvatarURL({
                         format: 'png',
                         dynamic: true,
                         size: 512
                     }),
-                    name: user.username
+                    name: user.username,
+                    isNitro:user.avatar && user.avatar.startsWith('a_')
                 };
 
                 if (guildId) {
@@ -78,7 +79,7 @@ class ChannelLinker extends global.Discord.Client {
         });
     };
 
-    sendHookMessage = (channelId, userId, msg) => {
+    sendHookMessage = (channelId, userId, msg,once) => {
         return new Promise(async (resolve, reject) => {
             const hook = this.hooks.get(channelId),
                 channel = this.channels.resolve(channelId),
@@ -86,15 +87,36 @@ class ChannelLinker extends global.Discord.Client {
                 data = {
                     username: user.name,
                     avatarURL: user.avatar,
-                    embeds: msg.embeds,
-                    tts: false,
-                    split: {
-                        maxLength: 2000
-                    }
+                    embeds: msg.embeds.filter(embed => embed.type == 'rich'),
+                    tts: false
                 };
+            let blockedAttachments = [] 
             if (msg.attachments.size) {
-                data.files = Array.from(msg.attachments).map(a => a[1].proxyURL);
+                data.files = [];
+                const fileArr = Array.from(msg.attachments).map(a => a[1]);
+                let totalSize = 0;
+                for(let i = 0; i < fileArr.length;++i)
+                {
+                    const file = fileArr[i];
+                    if((totalSize + file.size) > 8_000_000)
+                    {
+                        blockedAttachments.push(file);
+                        continue;
+                    }
+                    data.files.push(file.url);
+                    totalSize += file.size;
+                }
             }
+            if(blockedAttachments.length && once) //once used to only show the message once
+                msg.author.send({
+                    embed: new Discord.MessageEmbed()
+                        .setAuthor('Some files not successfully sent!')
+                        .setDescription(`The following files were unable to be sent: ${blockedAttachments.map(blockedAttachment => blockedAttachment.url).join(',')}.`+
+                        ((msg.attachments.size > 1) ? "Please try uploading these files in a seperate message for others to see them." : 
+                        (user.isNitro ? "The bot cannot upload an 8MB+ file like a nitro user" :
+                        "Due to it being next to impossible to determine if a file sent by a user can be sent to all connected channels by the bot, the limit we use has been reduced a little bit below the actual limit provided by discord. We're very sorry for the inconvenience.")))
+                        .setColor(0xD5622C)
+                }).catch(() => { }); //catch reject if user doesnt have DMs public
 
             // note that the '** **' produces a space since
             // the discord.js library makes the promise resolve to undefined

--- a/events/message.js
+++ b/events/message.js
@@ -4,11 +4,11 @@ module.exports = {
             if (message.webhookID && message.webhookID == client.hooks.get(message.channel.id).id) return;
             const hookMessages = [message];
 
-            for (let i = 0; i < client.connectedChannels.length; ++i) {
+            for (let i = 0,once = 0; i < client.connectedChannels.length; ++i) {
                 const channelId = client.connectedChannels[i];
                 if (channelId == message.channel.id) continue;
 
-                const msg = (await client.sendHookMessage(channelId, message.author.id, message))[0];
+                const msg = await client.sendHookMessage(channelId, message.author.id, message,once++);
                 hookMessages.push(msg);
                 client.parentMessageId.set(msg.id, message.id);
             }

--- a/events/message.js
+++ b/events/message.js
@@ -8,7 +8,7 @@ module.exports = {
                 const channelId = client.connectedChannels[i];
                 if (channelId == message.channel.id) continue;
 
-                const msg = await client.sendHookMessage(channelId, message.author.id, message,once++);
+                const msg = await client.sendHookMessage(channelId, message.author.id, message,!once++);
                 hookMessages.push(msg);
                 client.parentMessageId.set(msg.id, message.id);
             }

--- a/events/messageUpdate.js
+++ b/events/messageUpdate.js
@@ -1,14 +1,48 @@
-const { DiscordAPIError } = require("discord.js")
+const { APIMessage } = require("discord.js");
+/**
+ * Edits a message that was sent by this webhook.
+ * @param {MessageResolvable} message The message to edit
+ * @param {StringResolvable|APIMessage} [content] The new content for the message
+ * @param {WebhookEditMessageOptions|MessageEmbed|MessageEmbed[]} [options] The options to provide
+ * @returns {Promise<Message|Object>} Returns the raw message data if the webhook was instantiated as a
+ * {@link WebhookClient} or if the channel is uncached, otherwise a {@link Message} will be returned
+ */
+async function editMessage(message, content, options) {
+    const { data, files } = await (
+        (content.resolveData || (()=>undefined))() || APIMessage.create(this, content, options).resolveData()
+    ).resolveFiles();
+    const d = await this.client.api
+        .webhooks(this.id, this.token)
+        .messages(typeof message === 'string' ? message : message.id)
+        .patch({ data, files });
+
+    const channelManager = this.client.channels;
+    if(!channelManager) return d;
+    const messageManager = (channelManager.cache.get(d.channel_id) || {}).messages;
+    if (!messageManager) return d;
+
+    const existing = messageManager.cache.get(d.id);
+    if (!existing) return messageManager.add(d);
+
+    const clone = existing._clone();
+    clone._patch(d);
+    return clone;
+}
 
 module.exports = {
     run: function (message, newmsg) {
         if (client.connectedChannels.includes(message.channel.id) && message.content != newmsg.content) {
-            message.author.send({
-                embed: new Discord.MessageEmbed()
-                    .setAuthor('Edits are not seen by other servers on the UnderNet!')
-                    .setDescription('Consider voting on this [issue](https://support.discord.com/hc/en-us/community/posts/360034557771) to tell discord that you want to see this changed!')
-                    .setColor(0xD5622C)
-            }).catch(() => { }); //catch reject if user doesnt have DMs public
+            if (message.webhookID && message.webhookID == client.hooks.get(message.channel.id).id) 
+                return; //i'm unsure if the webhook can trigger a messageUpdate but just in case
+            const msgs = client.messages.get(message.id);
+            if (!msgs) return;
+
+            for (let i = 0; i < msgs.length; ++i) {
+                if(!msgs[i].webhookID) continue; //ignore message that was edited, which should be the only one without a webhookID
+                editMessage.call(this.hooks.get(msgs[i].channel.id),msgs[i],newmsg.content,{
+                    embeds: newmsg.embeds.filter(embed => embed.type == 'rich')
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
- Applied code from https://github.com/discordjs/discord.js/blob/7cabc1c490ddd9518528e12a58a746d65e43d4eb/src/structures/Webhook.js#L237 to allow editing until it's available in stable
- Fixed issue where person without avatar is unable to use bot
- Added 8MB (not MiB, smh discord) file limit to make sure bot can send at least part of the message
- Proxy URL sucks with non media attachments so replaced with normal cdn URL
- Fixed issue where bot would try to post non rich embeds (like YouTube embeds)
- Removed split as it's kinda redundant due to users not being able to post more than 2k characters